### PR TITLE
Update ParseDateTime to optionally apply timezone offset

### DIFF
--- a/test/Program.cs
+++ b/test/Program.cs
@@ -399,6 +399,7 @@ namespace Efferent.HL7.V2.Test
         {
             var date = MessageHelper.ParseDateTime(dateTimeString);
             Assert.IsNotNull(date);
+            Assert.AreEqual(DateTimeKind.Utc, date.Value.Kind);
         }
 
         [DataTestMethod]
@@ -422,10 +423,38 @@ namespace Efferent.HL7.V2.Test
         public void ParseDateTime_Correctness()
         {
             TimeSpan offset;
+            var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", applyOffset: false).Value;
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123), date);
+            Assert.AreEqual(DateTimeKind.Unspecified, date.Kind);
+        }
+
+        [TestMethod]
+        public void ParseDateTime_Correctness_WithOffset()
+        {
+            TimeSpan offset;
+            var date = MessageHelper.ParseDateTime("20151231234500.1234-2358").Value;
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).Subtract(new TimeSpan(-23, 58, 0)), date);
+            Assert.AreEqual(DateTimeKind.Utc, date.Kind);
+        }
+
+        [TestMethod]
+        public void ParseDateTime_TimeSpanOut_Correctness()
+        {
+            TimeSpan offset;
             var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", out offset).Value;
-            // Assert.AreEqual(0, d
-            Assert.AreEqual(date, new DateTime(2015, 12, 31, 23, 45, 00, 123));
-            Assert.AreEqual(offset, new TimeSpan(-23, 58, 0));
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123), date);
+            Assert.AreEqual(DateTimeKind.Unspecified, date.Kind);
+            Assert.AreEqual(new TimeSpan(-23, 58, 0), offset);
+        }
+
+        [TestMethod]
+        public void ParseDateTime_TimeSpanOut_Correctness_WithOffset()
+        {
+            TimeSpan offset;
+            var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", out offset, applyOffset: true).Value;
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).Subtract(new TimeSpan(-23, 58, 0)), date);
+            Assert.AreEqual(DateTimeKind.Utc, date.Kind);
+            Assert.AreEqual(new TimeSpan(-23, 58, 0), offset);
         }
 
         [TestMethod]
@@ -461,7 +490,7 @@ namespace Efferent.HL7.V2.Test
             {
             }
         }
-        
+
         [DataTestMethod]
         [DataRow("18151231")]
         [DataRow("19151231")]
@@ -470,6 +499,7 @@ namespace Efferent.HL7.V2.Test
         {
             var date = MessageHelper.ParseDateTime(dateTimeString);
             Assert.IsNotNull(date);
+            Assert.AreEqual(DateTimeKind.Utc, date.Value.Kind);
         }
 
         [DataTestMethod]
@@ -481,7 +511,7 @@ namespace Efferent.HL7.V2.Test
             var date = MessageHelper.ParseDateTime(dateTimeString);
             Assert.IsNull(date);
         }
-        
+
         [TestMethod]
         public void GetValueTest()
         {


### PR DESCRIPTION
### Enhancement to `ParseDateTime` methods in `MessageHelper.cs`:

Added an optional `applyOffset` parameter to `ParseDateTime` methods, allowing callers to choose whether to apply timezone offsets and return UTC or ignore offsets for unspecified timezones. Updated documentation to reflect these changes.