### PR TITLE
fix #12: Add support for sub-millisecond precision in DateTime parsing

### DIFF
--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -114,10 +114,8 @@ namespace Efferent.HL7.V2
                 int hours = groups[4].Success ? int.Parse(groups[4].Value, CultureInfo.InvariantCulture) : 0;
                 int mins = groups[5].Success ? int.Parse(groups[5].Value, CultureInfo.InvariantCulture) : 0;
 
-                float fsecs = groups[6].Success ? float.Parse(groups[6].Value, CultureInfo.InvariantCulture) : 0;
-                int secs = (int)Math.Truncate(fsecs);
-                int msecs = (int)Math.Truncate(fsecs * 1000) % 1000;
-
+                double secs = groups[6].Success ? double.Parse(groups[6].Value, CultureInfo.InvariantCulture) : 0;
+               
                 int tzh = groups[7].Success ? int.Parse(groups[7].Value, CultureInfo.InvariantCulture) : 0;
                 int tzm = groups[8].Success ? int.Parse(groups[8].Value, CultureInfo.InvariantCulture) : 0;
                 offset = new TimeSpan(tzh, tzm, 0);
@@ -125,12 +123,12 @@ namespace Efferent.HL7.V2
                 if (applyOffset)
                 {
                     // When applying offset, convert to UTC
-                    return new DateTime(year, month, day, hours, mins, secs, msecs, DateTimeKind.Utc).Subtract(offset);
+                    return new DateTime(year, month, day, hours, mins, 0, DateTimeKind.Utc).AddSeconds(secs).Subtract(offset);
                 }
                 else
                 {
                     // When not applying offset, return as Unspecified and leave to the caller to handle
-                    return new DateTime(year, month, day, hours, mins, secs, msecs);
+                    return new DateTime(year, month, day, hours, mins, 0).AddSeconds(secs);
                 }
             }
             catch

--- a/test/DateTimeTests.cs
+++ b/test/DateTimeTests.cs
@@ -48,7 +48,7 @@ namespace Efferent.HL7.V2.Test
         public void ParseDateTime_Correctness()
         {
             var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", applyOffset: false).Value;
-            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123), date);
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).AddMicroseconds(400), date);
             Assert.AreEqual(DateTimeKind.Unspecified, date.Kind);
         }
 
@@ -56,7 +56,7 @@ namespace Efferent.HL7.V2.Test
         public void ParseDateTime_Correctness_WithOffset()
         {
             var date = MessageHelper.ParseDateTime("20151231234500.1234-2358").Value;
-            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).Subtract(new TimeSpan(-23, 58, 0)), date);
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).AddMicroseconds(400).Subtract(new TimeSpan(-23, 58, 0)), date);
             Assert.AreEqual(DateTimeKind.Utc, date.Kind);
         }
 
@@ -64,8 +64,8 @@ namespace Efferent.HL7.V2.Test
         public void ParseDateTime_TimeSpanOut_Correctness()
         {
             TimeSpan offset;
-            var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", out offset).Value;
-            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123), date);
+            var date = MessageHelper.ParseDateTime("20151231234502.1234-2358", out offset).Value;
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 02, 123).AddMicroseconds(400), date);
             Assert.AreEqual(DateTimeKind.Unspecified, date.Kind);
             Assert.AreEqual(new TimeSpan(-23, 58, 0), offset);
         }
@@ -75,7 +75,7 @@ namespace Efferent.HL7.V2.Test
         {
             TimeSpan offset;
             var date = MessageHelper.ParseDateTime("20151231234500.1234-2358", out offset, applyOffset: true).Value;
-            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).Subtract(new TimeSpan(-23, 58, 0)), date);
+            Assert.AreEqual(new DateTime(2015, 12, 31, 23, 45, 00, 123).AddMicroseconds(400).Subtract(new TimeSpan(-23, 58, 0)), date);
             Assert.AreEqual(DateTimeKind.Utc, date.Kind);
             Assert.AreEqual(new TimeSpan(-23, 58, 0), offset);
         }


### PR DESCRIPTION
Fixes #12. Note there's still the odd bit of weirdness with high-precision DateTime calcs.  

Apparently a fix was [added to Net 7](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/datetime-add-precision) to improve precision of these operations, but I can still find the odd number of fractional seconds (eg, 1.234, which when added to a DateTime results in a value of 1.23399 etc.

Given the dual targeting of NetStandard and Net8 I'm not sure what else I can do about it?