### PR TITLE
Add .NET 9.0 and 10.0 support and update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,40 +12,43 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet: [ '8.0.x', '9.0.x', '10.0.x' ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup .NET Core
+
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
-      - name: Compile source (.NET 8 + .NETStandard)
-        run: |
-          dotnet build src/HL7-V2.csproj --configuration Release
-          dotnet build src/HL7-V2.csproj --configuration Release -f netstandard2.0
-      - name: Run unit tests (.NET 8 + .NETStandard)
-        run: |
-          dotnet test test/HL7Test.csproj --configuration Release --logger:trx
-          dotnet test test/HL7Test.csproj --configuration Release --logger:trx -f netstandard2.0
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Compile source
+        run: dotnet build src/HL7-V2.csproj --configuration Release
+
+      - name: Run unit tests
+        run: dotnet test test/HL7Test.csproj --configuration Release --logger:trx
         env:
           TEST_TITLE: HL7-V2 unit test
 
   deploy:
     runs-on: windows-latest
     needs: build
-    #if: contains(github.event.head_commit.modified, 'src/HL7-V2.csproj') || contains(github.event.head_commit.added, 'src/HL7-V2.csproj') || contains(github.event.head_commit.renamed, 'src/HL7-V2.csproj')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup .NET Core
+
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
+
       - name: Prepare NuGet package
         run: dotnet pack src/HL7-V2.csproj --configuration Release
+
       - name: Publish NuGet package
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          dotnet nuget push "src/bin/Release/**/*.nupkg" --api-key "$env:NUGET_API_KEY" --source "https://api.nuget.org/v3/index.json"
-      #dotnet nuget push "src/bin/Release/*.nupkg" -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "src/bin/Release/**/*.nupkg" --api-key "$env:NUGET_API_KEY" --source "https://api.nuget.org/v3/index.json"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It is not tied to any particular version of HL7 nor validates against one.
 
 ## Usage and compatibility
 
-This library is distributed via [nuget](https://www.nuget.org/packages/HL7-v2/latest) and targets two frameworks:
+This library is distributed via [nuget](https://www.nuget.org/packages/HL7-v2/latest) and targets three frameworks:
 - .NET Standard 2.0 for maximum compability, covering more than 40 .NET frameworks
-- .NET 8.0 for better performance under the new Microsoft's cross-platform framework
+- .NET 8.0, 9.0 and 10.0 for better performance under the new Microsoft's cross-platform framework
 
 For using the classes and methods mentioned below, declare de following namespace:
 

--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+        <TargetFrameworks>net10.0;net48</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
     </PropertyGroup>
 

--- a/src/HL7-V2.csproj
+++ b/src/HL7-V2.csproj
@@ -3,7 +3,7 @@
     <Description>Lightweight HL7 V2 library</Description>
     <Copyright>(c) Efferent, Inc.</Copyright>
     <VersionPrefix>3.7.1</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyName>HL7-V2</AssemblyName>
     <PackageId>HL7-V2</PackageId>
     <PackageTags>hl7;hl7-v2;hl7-parser;hl7-writer</PackageTags>

--- a/test/HL7test.csproj
+++ b/test/HL7test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>(c) Efferent, Inc.</Copyright>
     <VersionPrefix>3.7.1</VersionPrefix>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>HL7Test</AssemblyName>
     <PackageId>HL7Test</PackageId>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Extended library, test, and benchmark projects to target .NET 9.0 and 10.0. Updated GitHub Actions workflow to build and test against .NET 8.0, 9.0, and 10.0, and to deploy using .NET 10.0. Updated README to reflect new framework support.