### PR TITLE
Various performance improvements + Fixed bug breaking CustomDelimiterTest

### DIFF
--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net10.0;net48</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
+        <TargetFrameworks>net10.0;net8.0;net9.0;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-        <PackageReference Include="HL7-V2" Version="3.7.2" Condition="!$(DefineConstants.Contains('LOCAL_CODE'))" />
+        <PackageReference Include="HL7-V2" Version="3.7.3" Condition="!$(DefineConstants.Contains('LOCAL_CODE'))" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/ParseMessageBench.cs
+++ b/benchmarks/ParseMessageBench.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 using BenchmarkDotNet.Attributes;
@@ -28,7 +29,7 @@ namespace Benchmarks
 | ParseMessageAndGetValues | Net8 Nuget   | .NET 8.0           | HL7-V2 2.39 | 47.40 us |  1.00 | 11.7798 | 1.9531 |  180.7 KB |        1.00 |
  */
 
-        internal static readonly string _sampleMessage = File.ReadAllText("Sample-Orm.txt");
+        internal static readonly string SampleMessage = File.ReadAllText("Sample-Orm.txt");
 
         private class Config : ManualConfig
         {
@@ -36,19 +37,23 @@ namespace Benchmarks
             {
                 var baseJob = Job.ShortRun;
 
-                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=2.39").WithRuntime(CoreRuntime.Core80).WithId("Net8 Nuget").AsBaseline());
-                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=2.39").WithRuntime(ClrRuntime.Net48).WithId("Net4.8 Nuget"));
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(ClrRuntime.Net48).WithId("Net4.8 Nuget"));
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core80).WithId("Net8 Nuget").AsBaseline());
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core90).WithId("Net9 Nuget"));
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core10_0).WithId("Net10 Nuget"));
 
                 // custom config to include/exclude nuget reference or target project reference locally
                 AddJob(baseJob.WithRuntime(ClrRuntime.Net48).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net4.8 Local"));
                 AddJob(baseJob.WithRuntime(CoreRuntime.Core80).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net8 Local"));
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core90).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net9 Local"));
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core10_0).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net10 Local"));
             }
         }
 
         [Benchmark]
         public void ParseMessageAndGetValues()
         {
-            var msg = new Message(_sampleMessage);
+            var msg = new Message(SampleMessage);
             msg.ParseMessage(true);
 
             var ack = msg.GetACK(true);
@@ -57,6 +62,23 @@ namespace Benchmarks
             string receivingApp = ack.GetValue("MSH.5");
             string receivingFacility = ack.GetValue("MSH.6");
             string messageType = ack.GetValue("MSH.9");
+        }
+
+        [Benchmark]
+        public DateTime? ParseDateTime() 
+        {
+            MessageHelper.ParseDateTime("   20151231234500.1234+2358   ");
+            MessageHelper.ParseDateTime("20151231234500.1234+2358");
+            MessageHelper.ParseDateTime("20151231234500.1234-2358");
+            MessageHelper.ParseDateTime("20151231234500.1234");
+            MessageHelper.ParseDateTime("20151231234500.12");
+            MessageHelper.ParseDateTime("20151231234500");
+            MessageHelper.ParseDateTime("201512312345");
+            MessageHelper.ParseDateTime("2015123123");
+            MessageHelper.ParseDateTime("20151231");
+            MessageHelper.ParseDateTime("201512");
+            
+            return MessageHelper.ParseDateTime("2015");
         }
     }
 }

--- a/benchmarks/SerializeBench.cs
+++ b/benchmarks/SerializeBench.cs
@@ -27,33 +27,31 @@ namespace Benchmarks
 | SerializeMessage_Async | Net8 Local   | .NET 8.0           | Default                                | 15.39 us |  0.63 | 3.0518 | 0.0610 |  18.73 KB |        0.41 |
 | SerializeMessage_Async | Net8 Nuget   | .NET 8.0           | /p:PackageReference=HL7-V2,Version=3.7 | 24.56 us |  1.00 | 7.5073 | 0.1526 |  46.08 KB |        1.00 |
 */
-        private static readonly string _sampleMessage = File.ReadAllText("Sample-Orm.txt");
+        private static readonly string SampleMessage = File.ReadAllText("Sample-Orm.txt");
         private Message _msg;
 
-        private class Config : ManualConfig
+        private sealed class Config : ManualConfig
         {
             public Config()
             {
                 var baseJob = Job.ShortRun;
                 
-                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7")
-                    .WithRuntime(CoreRuntime.Core80)
-                    .WithId("Net8 Nuget").AsBaseline());
-                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7")
-                    .WithRuntime(ClrRuntime.Net48)
-                    .WithId("Net4.8 Nuget"));
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(ClrRuntime.Net48).WithId("Net4.8 Nuget").AsBaseline());
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core80).WithId("Net8 Nuget").AsBaseline());
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core90).WithId("Net9 Nuget"));
+                AddJob(baseJob.WithMsBuildArguments("/p:PackageReference=HL7-V2,Version=3.7.3").WithRuntime(CoreRuntime.Core10_0).WithId("Net10 Nuget"));
                 
-                AddJob(baseJob.WithRuntime(ClrRuntime.Net48).WithCustomBuildConfiguration("LOCAL_CODE")
-                    .WithId("Net4.8 Local"));
-                AddJob(baseJob.WithRuntime(CoreRuntime.Core80).WithCustomBuildConfiguration("LOCAL_CODE")
-                    .WithId("Net8 Local"));
+                AddJob(baseJob.WithRuntime(ClrRuntime.Net48).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net4.8 Local"));
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core80).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net8 Local"));
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core90).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net9 Local"));
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core10_0).WithCustomBuildConfiguration("LOCAL_CODE").WithId("Net10 Local"));
             }
         }
 
         [GlobalSetup]
         public void Setup()
         {
-            _msg = new Message(_sampleMessage);
+            _msg = new Message(SampleMessage);
             _msg.ParseMessage(true);
         }
 

--- a/src/HL7Encoding.cs
+++ b/src/HL7Encoding.cs
@@ -9,28 +9,60 @@ namespace Efferent.HL7.V2
     /// Manages HL7 encoding and decoding rules, including field, component, repetition, escape, and subcomponent delimiters.
     /// Provides methods to encode and decode HL7 message content according to these delimiters.
     /// </summary>
-    public class HL7Encoding
+    public class HL7Encoding 
     {
+        private bool _invalidChars = true;
+        
+        private char _fieldDelimiter = '|';        // \F\
+        private char _componentDelimiter = '^';    // \S\
+        private char _repeatDelimiter = '~';       // \R\
+        private char _escapeCharacter = '\\';      // \E\
+        private char _subComponentDelimiter = '&'; // \T\
+
         /// <summary>
         /// Gets or sets the field delimiter character used to separate fields within a segment.
         /// </summary>
-        public char FieldDelimiter { get; set; } = '|';        // \F\
+        public char FieldDelimiter 
+        {
+            get => _fieldDelimiter;
+            set { _fieldDelimiter = value; _invalidChars = true; }
+        }
+
         /// <summary>
         /// Gets or sets the component delimiter character used to separate components within a field.
         /// </summary>
-        public char ComponentDelimiter { get; set; } = '^';    // \S\
+        public char ComponentDelimiter 
+        {
+            get => _componentDelimiter;
+            set { _componentDelimiter = value; _invalidChars = true; }
+        }
+
         /// <summary>
         /// Gets or sets the repeat delimiter character used to separate repeated fields or components.
         /// </summary>
-        public char RepeatDelimiter { get; set; } = '~';       // \R\
+        public char RepeatDelimiter 
+        {
+            get => _repeatDelimiter;
+            set { _repeatDelimiter = value; _invalidChars = true; }
+        }
+
         /// <summary>
         /// Gets or sets the escape character used to denote escaped sequences within HL7 content.
         /// </summary>
-        public char EscapeCharacter { get; set; } = '\\';      // \E\
+        public char EscapeCharacter 
+        {
+            get => _escapeCharacter;
+            set { _escapeCharacter = value; _invalidChars = true; }
+        }
+
         /// <summary>
         /// Gets or sets the subcomponent delimiter character used to separate subcomponents within a component.
         /// </summary>
-        public char SubComponentDelimiter { get; set; } = '&'; // \T\
+        public char SubComponentDelimiter 
+        {
+            get => _subComponentDelimiter;
+            set { _subComponentDelimiter = value; _invalidChars = true; }
+        }
         /// <summary>
         /// Gets or sets the segment delimiter string used to separate segments within an HL7 message.
         /// </summary>
@@ -47,10 +79,16 @@ namespace Efferent.HL7.V2
         private static readonly string[] _segmentDelimiters = { "\r\n", "\n\r", "\r", "\n" };
         private char[] _charsThatMightNeedEncoding;
 
-        public HL7Encoding()
+        private char[] CharsThatMightNeedEncoding() 
         {
-            // set the defaults
-            _charsThatMightNeedEncoding = new[] { '<', '\r', '\n', FieldDelimiter, ComponentDelimiter, RepeatDelimiter, EscapeCharacter, SubComponentDelimiter };
+            if (_invalidChars) 
+            {
+                _charsThatMightNeedEncoding = new[] { '<', '\r', '\n', FieldDelimiter, ComponentDelimiter, RepeatDelimiter, EscapeCharacter, SubComponentDelimiter };
+
+                _invalidChars = false;
+            }
+            
+            return _charsThatMightNeedEncoding;
         }
 
         /// <summary>
@@ -73,7 +111,6 @@ namespace Efferent.HL7.V2
                 this.EscapeCharacter = delimiters[3];
                 this.SubComponentDelimiter = delimiters[4];
             }
-            _charsThatMightNeedEncoding = new[] { '<', '\r', '\n', FieldDelimiter, ComponentDelimiter, RepeatDelimiter, EscapeCharacter, SubComponentDelimiter };
         }
 
         /// <summary>
@@ -100,7 +137,7 @@ namespace Efferent.HL7.V2
         /// </summary>
         /// <param name="val">The string value to encode.</param>
         /// <returns>The encoded string with special characters escaped.</returns>
-        public  string Encode(string val)
+        public string Encode(string val)
         {
             if (val == null)
                 return PresentButNull;
@@ -109,9 +146,8 @@ namespace Efferent.HL7.V2
                 return val;
 
             // If there's nothing that needs encoding, just return the value as-is
-            // Disabled as it was breaking the CustomDelimiterTest() test method
-            // if (val.IndexOfAny(_charsThatMightNeedEncoding) < 0)
-            //     return val;
+             if (val.IndexOfAny(CharsThatMightNeedEncoding()) < 0)
+                 return val;
 
             var sb = new StringBuilder();
 

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Efferent.HL7.V2
 {
-    public class Message
+    public partial class Message
     {
         private List<string> allSegments = null;
         internal Dictionary<string, List<Segment>> SegmentList { get; set; } = new Dictionary<string, List<Segment>>();
@@ -25,10 +25,30 @@ namespace Efferent.HL7.V2
         public HL7Encoding Encoding { get; set; } = new HL7Encoding();
 
         private static readonly char[] _queryDelimiter = ['.'];
-
-        private const string segmentRegex = @"^([A-Z][A-Z][A-Z1-9])([\(\[]([0-9]+)[\)\]]){0,1}$";
-        private const string fieldRegex = @"^([0-9]+)([\(\[]([0-9]+)[\)\]]){0,1}$";
-        private const string otherRegEx = @"^[1-9]([0-9]{1,2})?$";
+        
+        private const string SEGMENT_REGEX_EXPR = @"^([A-Z][A-Z][A-Z1-9])([\(\[]([0-9]+)[\)\]]){0,1}$";
+        private const string FIELD_REGEX_EXPR = @"^([0-9]+)([\(\[]([0-9]+)[\)\]]){0,1}$";
+        private const string OTHER_REG_EXPR = "^[1-9]([0-9]{1,2})?$";
+        
+        
+#if NETSTANDARD2_0
+        private static readonly Regex SegmentRegex = new Regex(SEGMENT_REGEX_EXPR, RegexOptions.Compiled);
+        private static readonly Regex FieldSegmentRegex = new Regex(FIELD_REGEX_EXPR, RegexOptions.Compiled);
+        private static readonly Regex OtherRegex = new Regex(OTHER_REG_EXPR, RegexOptions.Compiled);
+#else
+        [GeneratedRegex(SEGMENT_REGEX_EXPR)]
+        private static partial Regex SegmentRegexMethod();
+        [GeneratedRegex(FIELD_REGEX_EXPR)]
+        private static partial Regex FieldSegmentRegexMethod();
+        [GeneratedRegex(OTHER_REG_EXPR)]
+        private static partial Regex OtherRegexMethod();
+        
+        private static readonly Regex SegmentRegex = SegmentRegexMethod();
+        private static readonly Regex FieldSegmentRegex = FieldSegmentRegexMethod();
+        private static readonly Regex OtherRegex = OtherRegexMethod();
+#endif
+        
+        
 
         public Message()
         {
@@ -232,16 +252,16 @@ namespace Efferent.HL7.V2
 
             if (isValid)
             {
-                var matches = Regex.Matches(allComponents[0], segmentRegex);
+                var match = SegmentRegex.Match(allComponents[0]);
 
-                if (matches.Count < 1)
+                if (!match.Success)
                     throw new HL7Exception("Request format is not valid: " + strValueFormat);
 
-                segmentName = matches[0].Groups[1].Value;
+                segmentName = match.Groups[1].Value;
 
-                if (matches[0].Length > 3)
+                if (match.Length > 3)
                 {
-                    if (Int32.TryParse(matches[0].Groups[3].Value, out segmentOccurrence))
+                    if (int.TryParse(match.Groups[3].Value, out segmentOccurrence))
                         segmentOccurrence--;
                 }
 
@@ -251,9 +271,9 @@ namespace Efferent.HL7.V2
 
                     if (comCount == 4)
                     {
-                        if (Int32.TryParse(allComponents[2], out componentIndex))
+                        if (int.TryParse(allComponents[2], out componentIndex))
                         {
-                            if (Int32.TryParse(allComponents[3], out int subComponentIndex))
+                            if (int.TryParse(allComponents[3], out int subComponentIndex))
                             {
                                 try
                                 {
@@ -269,7 +289,7 @@ namespace Efferent.HL7.V2
                     }
                     else if (comCount == 3)
                     {
-                        if (Int32.TryParse(allComponents[2], out componentIndex))
+                        if (int.TryParse(allComponents[2], out componentIndex))
                         {
                             try
                             {
@@ -345,9 +365,9 @@ namespace Efferent.HL7.V2
                     {
                         if (comCount == 4)
                         {
-                            if (Int32.TryParse(allComponents[2], out componentIndex))
+                            if (int.TryParse(allComponents[2], out componentIndex))
                             {
-                                if (Int32.TryParse(allComponents[3], out int subComponentIndex))
+                                if (int.TryParse(allComponents[3], out int subComponentIndex))
                                 {
                                     try
                                     {
@@ -364,7 +384,7 @@ namespace Efferent.HL7.V2
                         }
                         else if (comCount == 3)
                         {
-                            if (Int32.TryParse(allComponents[2], out componentIndex))
+                            if (int.TryParse(allComponents[2], out componentIndex))
                             {
                                 try
                                 {
@@ -431,7 +451,7 @@ namespace Efferent.HL7.V2
                 {
                     try
                     {
-                        var segment = SegmentList[segmentName].First();
+                        var segment = SegmentList[segmentName][0];
                         var field = getField(segment, allComponents[1]);
 
                         isComponentized = field.IsComponentized;
@@ -469,7 +489,7 @@ namespace Efferent.HL7.V2
             if (isValid)
             {
                 var segmentName = allComponents[0];
-                var segment = SegmentList[segmentName].First();
+                var segment = SegmentList[segmentName][0];
 
                 if (comCount >= 2)
                 {
@@ -515,10 +535,10 @@ namespace Efferent.HL7.V2
                 {
                     try
                     {
-                        var segment = SegmentList[segmentName].First();
+                        var segment = SegmentList[segmentName][0];
                         var field = getField(segment, allComponents[1]);
 
-                        if (Int32.TryParse(allComponents[2], out int componentIndex))
+                        if (int.TryParse(allComponents[2], out int componentIndex))
                             isSubComponentized = field.ComponentList[componentIndex - 1].IsSubComponentized;
                     }
                     catch (Exception ex)
@@ -708,7 +728,7 @@ namespace Efferent.HL7.V2
             if (this.MessageStructure != "ACK")
             {
                 var dateString = MessageHelper.LongDateWithFractionOfSecond(DateTime.Now);
-                var msh = this.SegmentList["MSH"].First();
+                var msh = this.SegmentList["MSH"][0];
                 var delim = this.Encoding.FieldDelimiter;
 
                 response.Append("MSH").Append(this.Encoding.AllDelimiters).Append(delim).Append(msh.FieldList[4].Value).Append(delim).Append(msh.FieldList[5].Value).Append(delim)
@@ -738,23 +758,24 @@ namespace Efferent.HL7.V2
         /// <summary>
         /// Gets a field object within a segment by index
         /// </summary>
-        /// <param name="segment">The segment object to search in/param>
-        /// <param name="index">The index of the field within the segment/param>
+        /// <param name="segment">The segment object to search in</param>
+        /// <param name="index">The index of the field within the segment</param>
         /// <returns>A Field object</returns>
         private static Field getField(Segment segment, string index)
         {
             int repetition = 0;
-            var matches = Regex.Matches(index, fieldRegex);
 
-            if (matches.Count < 1)
+            var match = FieldSegmentRegex.Match(index);
+            
+            if (!match.Success)
                 throw new HL7Exception("Invalid field index");
 
-            if (Int32.TryParse(matches[0].Groups[1].Value, out int fieldIndex))
+            if (int.TryParse(match.Groups[1].Value, out int fieldIndex))
                 fieldIndex--;
 
-            if (matches[0].Length > 3)
+            if (match.Length > 3)
             {
-                if (Int32.TryParse(matches[0].Groups[3].Value, out repetition))
+                if (int.TryParse(match.Groups[3].Value, out repetition))
                     repetition--;
             }
 
@@ -771,17 +792,17 @@ namespace Efferent.HL7.V2
         /// <summary>
         /// Determines if a segment field has repetitions
         /// </summary>
-        /// <param name="segment">The segment object to search in/param>
-        /// <param name="index">The index of the field within the segment/param>
+        /// <param name="segment">The segment object to search in</param>
+        /// <param name="index">The index of the field within the segment</param>
         /// <returns>A boolean indicating whether the field has repetitions</returns>
         private static int getFieldRepetitions(Segment segment, string index)
         {
-            var matches = Regex.Matches(index, fieldRegex);
+            var match = FieldSegmentRegex.Match(index);
 
-            if (matches.Count < 1)
+            if (!match.Success)
                 return 0;
 
-            if (Int32.TryParse(matches[0].Groups[1].Value, out int fieldIndex))
+            if (int.TryParse(match.Groups[1].Value, out int fieldIndex))
                 fieldIndex--;
 
             var field = segment.FieldList[fieldIndex];
@@ -829,8 +850,9 @@ namespace Efferent.HL7.V2
                             continue;
 
                         string segmentName = strSegment.Substring(0, 3);
-                        bool isValidSegmentName = Regex.IsMatch(segmentName, segmentRegex);
 
+                        bool isValidSegmentName = SegmentRegex.IsMatch(segmentName);
+                        
                         if (!isValidSegmentName)
                             throw new HL7Exception("Invalid segment name found: " + strSegment, HL7Exception.BadMessage);
 
@@ -944,35 +966,49 @@ namespace Efferent.HL7.V2
 
             if (allComponents.Length > 0)
             {
-                if (Regex.IsMatch(allComponents[0], segmentRegex))
+                if (SegmentRegex.IsMatch(allComponents[0]))
                 {
                     for (int i = 1; i < allComponents.Length; i++)
                     {
-                        if (i == 1 && Regex.IsMatch(allComponents[i], fieldRegex))
+                        if (i == 1 && FieldSegmentRegex.IsMatch(allComponents[i]))
                             isValid = true;
-                        else if (i > 1 && Regex.IsMatch(allComponents[i], otherRegEx))
+                        else if (i > 1 && OtherRegex.IsMatch(allComponents[i]))
                             isValid = true;
                         else
                             return false;
                     }
-                }
-                else
-                {
-                    isValid = false;
                 }
             }
 
             return isValid;
         }
 
+        private Regex _hexSequenceRegex;
+        private char _hexSequenceEscapeChar;
+
+        private Regex GetHexSequenceRegex() 
+        {
+            var escChar = Encoding.EscapeCharacter;
+
+            // Stale cache
+            if (_hexSequenceRegex == null || _hexSequenceEscapeChar != escChar) 
+            {
+                var esc = "\\x" + ((int)Encoding.EscapeCharacter).ToString("X2", CultureInfo.InvariantCulture);
+                
+                _hexSequenceRegex = new Regex(esc + "X([0-9A-Fa-f]*)" + esc, RegexOptions.Compiled);
+                _hexSequenceEscapeChar = escChar;
+            }
+
+            return _hexSequenceRegex;
+        }
+        
         /// <summary>
         /// Decodes or normalizes hexadecimal escape sequences from all message lines.
         /// </summary>
         /// <param name="message">Array of message lines</param>
         private bool DecodeHexaSequences(IList<string> message, bool decomposeMultibyteLineBreaks = false)
         {
-            var esc = "\\x" + ((int)this.Encoding.EscapeCharacter).ToString("X2", CultureInfo.InvariantCulture);
-            var regex = new Regex(esc + "X([0-9A-Fa-f]*)" + esc);
+            var regex = GetHexSequenceRegex();
             bool hasChanged = false;
 
             for (int i=0; i<message.Count; i++)

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -982,25 +982,6 @@ namespace Efferent.HL7.V2
 
             return isValid;
         }
-
-        private Regex _hexSequenceRegex;
-        private char _hexSequenceEscapeChar;
-
-        private Regex GetHexSequenceRegex() 
-        {
-            var escChar = Encoding.EscapeCharacter;
-
-            // Stale cache
-            if (_hexSequenceRegex == null || _hexSequenceEscapeChar != escChar) 
-            {
-                var esc = "\\x" + ((int)Encoding.EscapeCharacter).ToString("X2", CultureInfo.InvariantCulture);
-                
-                _hexSequenceRegex = new Regex(esc + "X([0-9A-Fa-f]*)" + esc, RegexOptions.Compiled);
-                _hexSequenceEscapeChar = escChar;
-            }
-
-            return _hexSequenceRegex;
-        }
         
         /// <summary>
         /// Decodes or normalizes hexadecimal escape sequences from all message lines.
@@ -1008,7 +989,8 @@ namespace Efferent.HL7.V2
         /// <param name="message">Array of message lines</param>
         private bool DecodeHexaSequences(IList<string> message, bool decomposeMultibyteLineBreaks = false)
         {
-            var regex = GetHexSequenceRegex();
+            var esc = "\\x" + ((int)this.Encoding.EscapeCharacter).ToString("X2", CultureInfo.InvariantCulture);
+            var regex = new Regex(esc + "X([0-9A-Fa-f]*)" + esc);
             bool hasChanged = false;
 
             for (int i=0; i<message.Count; i++)

--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -20,7 +20,9 @@ namespace Efferent.HL7.V2
         private static readonly Regex DateTimeRegex = new Regex(DATETIME_EXPR, RegexOptions.Singleline | RegexOptions.Compiled);
 #else
         [GeneratedRegex(DATETIME_EXPR, RegexOptions.Singleline)]
-        private static partial Regex DateTimeRegex();
+        private static partial Regex DateTimeRegexMethod();
+        
+        private static readonly Regex DateTimeRegex = DateTimeRegexMethod();
 #endif
 
         /// <summary>
@@ -176,11 +178,7 @@ namespace Efferent.HL7.V2
         {
             offset = TimeSpan.Zero;
 
-#if NETSTANDARD2_0
             var match = DateTimeRegex.Match(dateTimeString);
-#else
-            var match = DateTimeRegex().Match(dateTimeString);
-#endif
             
             if (!match.Success) 
             {

--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -10,9 +10,18 @@ namespace Efferent.HL7.V2
     /// <summary>
     /// Provides utility methods for parsing, splitting, formatting, and serializing HL7 messages.
     /// </summary>
-    public static class MessageHelper
+    public static partial class MessageHelper
     {
-        private static readonly string[] lineSeparators = { "\r\n", "\n\r", "\r", "\n" };
+        private static readonly string[] LineSeparators = { "\r\n", "\n\r", "\r", "\n" };
+
+        private const string DATETIME_EXPR = @"^\s*((?:18|19|20)[0-9]{2})(?:(1[0-2]|0[1-9])(?:(3[0-1]|[1-2][0-9]|0[1-9])(?:([0-1][0-9]|2[0-3])(?:([0-5][0-9])(?:([0-5][0-9](?:\.[0-9]{1,4})?)?)?)?)?)?)?(?:([+-][0-1][0-9]|[+-]2[0-3])([0-5][0-9]))?\s*$";
+        
+#if NETSTANDARD2_0
+        private static readonly Regex DateTimeRegex = new Regex(DATETIME_EXPR, RegexOptions.Singleline | RegexOptions.Compiled);
+#else
+        [GeneratedRegex(DATETIME_EXPR, RegexOptions.Singleline)]
+        private static partial Regex DateTimeRegex();
+#endif
 
         /// <summary>
         /// Splits a string into a list of substrings based on the specified string delimiter.
@@ -23,7 +32,11 @@ namespace Efferent.HL7.V2
         /// <returns>A list of substrings obtained by splitting the input string.</returns>
         public static List<string> SplitString(string strStringToSplit, string splitBy, StringSplitOptions splitOptions = StringSplitOptions.None)
         {
+#if NETSTANDARD2_0
             return strStringToSplit.Split(new string[] { splitBy }, splitOptions).ToList();
+#else
+            return strStringToSplit.Split(splitBy, splitOptions).ToList();
+#endif
         }
 
         /// <summary>
@@ -35,7 +48,11 @@ namespace Efferent.HL7.V2
         /// <returns>A list of substrings obtained by splitting the input string.</returns>
         public static List<string> SplitString(string strStringToSplit, char chSplitBy, StringSplitOptions splitOptions = StringSplitOptions.None)
         {
+#if NETSTANDARD2_0
             return strStringToSplit.Split(new char[] { chSplitBy }, splitOptions).ToList();
+#else
+            return strStringToSplit.Split(chSplitBy, splitOptions).ToList();
+#endif
         }
 
         /// <summary>
@@ -57,7 +74,7 @@ namespace Efferent.HL7.V2
         /// <returns>A list of segment strings extracted from the message, excluding empty or whitespace-only segments.</returns>
         public static List<string> SplitMessage(string message)
         {
-            return message.Split(lineSeparators, StringSplitOptions.None).Where(m => !string.IsNullOrWhiteSpace(m)).ToList();
+            return message.Split(LineSeparators, StringSplitOptions.None).Where(m => !string.IsNullOrWhiteSpace(m)).ToList();
         }
 
         /// <summary>
@@ -121,9 +138,9 @@ namespace Efferent.HL7.V2
         /// <inheritdoc cref="ParseDateTime(string, out TimeZone, bool, bool)" path="/exception[@cref='FormatException']"/>
         public static DateTime? ParseDateTime(string dateTimeString, bool throwException = false, bool applyOffset = true)
         {
-            return ParseDateTime(dateTimeString, out TimeSpan offset, throwException, applyOffset);
+            return ParseDateTime(dateTimeString, out var offset, throwException, applyOffset);
         }
-
+        
         /// <summary>
         /// Parses an HL7 date time string into a <see cref="DateTime"/> object and extracts the timezone offset.
         /// </summary>
@@ -157,39 +174,52 @@ namespace Efferent.HL7.V2
         /// <exception cref="FormatException">Thrown when <paramref name="throwException"/> is <c>true</c> and the input string is not in a valid HL7 date time format.</exception>
         public static DateTime? ParseDateTime(string dateTimeString, out TimeSpan offset, bool throwException = false, bool applyOffset = false)
         {
-            var expr = @"^\s*((?:18|19|20)[0-9]{2})(?:(1[0-2]|0[1-9])(?:(3[0-1]|[1-2][0-9]|0[1-9])(?:([0-1][0-9]|2[0-3])(?:([0-5][0-9])(?:([0-5][0-9](?:\.[0-9]{1,4})?)?)?)?)?)?)?(?:([+-][0-1][0-9]|[+-]2[0-3])([0-5][0-9]))?\s*$";
-            var matches = Regex.Matches(dateTimeString, expr, RegexOptions.Singleline);
+            offset = TimeSpan.Zero;
 
-            offset = new TimeSpan();
-
+#if NETSTANDARD2_0
+            var match = DateTimeRegex.Match(dateTimeString);
+#else
+            var match = DateTimeRegex().Match(dateTimeString);
+#endif
+            
+            if (!match.Success) 
+            {
+                return throwException 
+                    ? throw new FormatException("Invalid date format") 
+                    : null;
+            }
+            
             try
             {
-                if (matches.Count != 1)
-                    throw new FormatException("Invalid date format");
+                var groups = match.Groups;
 
-                var groups = matches[0].Groups;
+#if NETSTANDARD2_0
                 int year = int.Parse(groups[1].Value, CultureInfo.InvariantCulture);
                 int month = groups[2].Success ? int.Parse(groups[2].Value, CultureInfo.InvariantCulture) : 1;
                 int day = groups[3].Success ? int.Parse(groups[3].Value, CultureInfo.InvariantCulture) : 1;
                 int hours = groups[4].Success ? int.Parse(groups[4].Value, CultureInfo.InvariantCulture) : 0;
                 int mins = groups[5].Success ? int.Parse(groups[5].Value, CultureInfo.InvariantCulture) : 0;
-
                 double secs = groups[6].Success ? double.Parse(groups[6].Value, CultureInfo.InvariantCulture) : 0;
-               
                 int tzh = groups[7].Success ? int.Parse(groups[7].Value, CultureInfo.InvariantCulture) : 0;
                 int tzm = groups[8].Success ? int.Parse(groups[8].Value, CultureInfo.InvariantCulture) : 0;
+#else
+                int year = int.Parse(groups[1].ValueSpan, CultureInfo.InvariantCulture);
+                int month = groups[2].Success ? int.Parse(groups[2].ValueSpan, CultureInfo.InvariantCulture) : 1;
+                int day = groups[3].Success ? int.Parse(groups[3].ValueSpan, CultureInfo.InvariantCulture) : 1;
+                int hours = groups[4].Success ? int.Parse(groups[4].ValueSpan, CultureInfo.InvariantCulture) : 0;
+                int mins = groups[5].Success ? int.Parse(groups[5].ValueSpan, CultureInfo.InvariantCulture) : 0;
+                double secs = groups[6].Success ? double.Parse(groups[6].ValueSpan, CultureInfo.InvariantCulture) : 0;
+                int tzh = groups[7].Success ? int.Parse(groups[7].ValueSpan, CultureInfo.InvariantCulture) : 0;
+                int tzm = groups[8].Success ? int.Parse(groups[8].ValueSpan, CultureInfo.InvariantCulture) : 0;
+#endif
+                
                 offset = new TimeSpan(tzh, tzm, 0);
 
-                if (applyOffset)
-                {
+                return applyOffset ?
                     // When applying offset, convert to UTC
-                    return new DateTime(year, month, day, hours, mins, 0, DateTimeKind.Utc).AddSeconds(secs).Subtract(offset);
-                }
-                else
-                {
+                    new DateTime(year, month, day, hours, mins, 0, DateTimeKind.Utc).AddSeconds(secs).Subtract(offset) :
                     // When not applying offset, return as Unspecified and leave to the caller to handle
-                    return new DateTime(year, month, day, hours, mins, 0).AddSeconds(secs);
-                }
+                    new DateTime(year, month, day, hours, mins, 0).AddSeconds(secs);
             }
             catch
             {
@@ -199,7 +229,7 @@ namespace Efferent.HL7.V2
                 return null;
             }
         }
-
+        
         /// <summary>
         /// Serializes an HL7 message string into an MLLP (Minimal Lower Layer Protocol) framed byte array.
         /// </summary>

--- a/test/HL7test.csproj
+++ b/test/HL7test.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.1" />
+    <PackageReference Include="MSTest" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Utilize static/source generated regex when feasible
  - The regex in `DecodeHexaSequences` looks to be small enough; the interpreted engine is faster than trying to be clever with caching/source generation
- Utilize improvements in .NET 8+ to help performance in those frameworks
- Fixed bug causing `CustomDelimiterTest` to sporadically fail when `HL7Encoding.Encode` is allowed to fail fast
  - Basically, even though the delimiters were being updated, `_charsThatMightNeedEncoding` was only being set in the constructor, before the delimiters were being updated
  - This was further exposed because of the usage of `DateTime.Now` in `AddSegmentMSH`
    - `_charsThatMightNeedEncoding` would have the default encodings, so it'd fail to encode a timestamp including a "1", for example
  - The fix was to add a method that ensured `_charsThatMightNeedEncoding` *always* reflected the current state of the delimiters + some caching to reduce allocations

Here are some benchmarks taken to show the improvements:
`ParseMessageBench.cs`
```
| Method                   | Job         | Runtime   | Arguments                                | Mean      | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------------------------|------------ |---------- |----------------------------------------- |----------:|------:|-------:|-------:|----------:|------------:|
| ParseMessageAndGetValues | Net10 Local | .NET 10.0 | Default                                  | 23.830 us |  0.89 | 2.0752 | 0.3052 | 102.58 KB |        0.91 |
| ParseMessageAndGetValues | Net10 Nuget | .NET 10.0 | /p:PackageReference=HL7-V2,Version=3.7.3 | 26.242 us |  0.98 | 2.2888 | 0.3357 | 113.16 KB |        1.00 |
| ParseMessageAndGetValues | Net9 Local  | .NET 9.0  | Default                                  | 24.230 us |  0.90 | 2.0752 | 0.2441 | 102.56 KB |        0.91 |
| ParseMessageAndGetValues | Net9 Nuget  | .NET 9.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 26.912 us |  1.00 | 2.1973 | 0.2441 | 113.15 KB |        1.00 |
| ParseMessageAndGetValues | Net8 Local  | .NET 8.0  | Default                                  | 24.325 us |  0.91 | 2.0752 | 0.2441 | 102.54 KB |        0.91 |
| ParseMessageAndGetValues | Net8 Nuget  | .NET 8.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 26.823 us |  1.00 | 2.1973 | 0.2441 | 113.13 KB |        1.00 |
|                          |             |           |                                          |           |       |        |        |           |             |
| ParseDateTime            | Net10 Local | .NET 10.0 | Default                                  |  2.385 us |  0.51 | 0.2403 |      - |  11.92 KB |        0.78 |
| ParseDateTime            | Net10 Nuget | .NET 10.0 | /p:PackageReference=HL7-V2,Version=3.7.3 |  4.432 us |  0.96 | 0.3052 |      - |  15.25 KB |        1.00 |
| ParseDateTime            | Net9 Local  | .NET 9.0  | Default                                  |  2.601 us |  0.56 | 0.2403 |      - |  11.92 KB |        0.78 |
| ParseDateTime            | Net9 Nuget  | .NET 9.0  | /p:PackageReference=HL7-V2,Version=3.7.3 |  4.517 us |  0.97 | 0.3052 |      - |  15.25 KB |        1.00 |
| ParseDateTime            | Net8 Local  | .NET 8.0  | Default                                  |  2.566 us |  0.55 | 0.2403 |      - |  11.92 KB |        0.78 |
| ParseDateTime            | Net8 Nuget  | .NET 8.0  | /p:PackageReference=HL7-V2,Version=3.7.3 |  4.635 us |  1.00 | 0.3052 |      - |  15.25 KB |        1.00 |
```

`SerializeBench.cs`
```
| Method                 | Job         | Runtime   | Arguments                                | Mean     | Ratio | Gen0   | Allocated | Alloc Ratio |
|----------------------- |------------ |---------- |----------------------------------------- |---------:|------:|-------:|----------:|------------:|
| SerializeMessage_Sync  | Net10 Local | .NET 10.0 | Default                                  | 4.529 us |  0.80 | 0.1755 |   8.95 KB |        0.52 |
| SerializeMessage_Sync  | Net10 Nuget | .NET 10.0 | /p:PackageReference=HL7-V2,Version=3.7.3 | 5.374 us |  0.94 | 0.3510 |  17.32 KB |        1.00 |
| SerializeMessage_Sync  | Net9 Local  | .NET 9.0  | Default                                  | 4.824 us |  0.85 | 0.1755 |   8.94 KB |        0.52 |
| SerializeMessage_Sync  | Net9 Nuget  | .NET 9.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 5.719 us |  1.01 | 0.3510 |  17.31 KB |        1.00 |
| SerializeMessage_Sync  | Net8 Local  | .NET 8.0  | Default                                  | 4.939 us |  0.87 | 0.1755 |   8.91 KB |        0.52 |
| SerializeMessage_Sync  | Net8 Nuget  | .NET 8.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 5.688 us |  1.00 | 0.3510 |  17.28 KB |        1.00 |
|                        |             |           |                                          |          |       |        |           |             |
| SerializeMessage_Async | Net10 Local | .NET 10.0 | Default                                  | 6.849 us |  0.81 | 0.2060 |  10.38 KB |        0.55 |
| SerializeMessage_Async | Net10 Nuget | .NET 10.0 | /p:PackageReference=HL7-V2,Version=3.7.3 | 7.732 us |  0.92 | 0.3815 |  18.76 KB |        1.00 |
| SerializeMessage_Async | Net9 Local  | .NET 9.0  | Default                                  | 7.328 us |  0.87 | 0.2060 |  10.38 KB |        0.55 |
| SerializeMessage_Async | Net9 Nuget  | .NET 9.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 7.935 us |  0.94 | 0.3815 |  18.76 KB |        1.00 |
| SerializeMessage_Async | Net8 Local  | .NET 8.0  | Default                                  | 7.760 us |  0.92 | 0.1984 |  10.35 KB |        0.55 |
| SerializeMessage_Async | Net8 Nuget  | .NET 8.0  | /p:PackageReference=HL7-V2,Version=3.7.3 | 8.423 us |  1.00 | 0.3815 |  18.73 KB |        1.00 |
```

\* I'm on Linux, so I don't have .NET Framework 4.8 benchmarks